### PR TITLE
Fix Null Room Errors

### DIFF
--- a/Source/FridgeUtility.cs
+++ b/Source/FridgeUtility.cs
@@ -55,7 +55,11 @@ namespace SimpleFridge
 				}
 
 				//Update power consumption
-				fridge.powerOutputInt = fridge.Props.basePowerConsumption * powerCurve.Evaluate(fridge.parent.GetRoom().Temperature);
+				Room fridgeRoom = fridge.parent.GetRoom();
+				float temperature;
+				if (fridgeRoom == null) temperature = map.mapTemperature.OutdoorTemp;
+				else temperature = fridgeRoom.Temperature;
+				fridge.powerOutputInt = fridge.Props.basePowerConsumption * powerCurve.Evaluate(temperature);
 
 				//While we're at it, update the grid the current power status
 				UpdateFridgeGrid(fridge);


### PR DESCRIPTION
Fixes a NullReferenceException caused by `FridgeUtility.Tick()` when a fridges room is null.

In the edge case of a fridge not having a room (e.g. being in a wall), it will fallback to the outdoor temperature of the map.

Averaging temperatures of adjacent rooms could also be a solution, which I can implement if you'd like that instead.

- Example [player.log](https://github.com/Owlchemist/simple-utilities-fridge/files/14151234/Player.log) of the error.
- Originally identified when playing with [Utilities: Fridge Unofficial Wall Edition](https://steamcommunity.com/sharedfiles/filedetails/?id=3016156378)

- Resolves #1